### PR TITLE
Storing username/accesstoken with Oauth and backend cleanup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,13 +4,11 @@ const path = require('path');
 declare const MAIN_WINDOW_WEBPACK_ENTRY: any;
 
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.
-if (require('electron-squirrel-startup')) { // eslint-disable-line global-require
-  app.quit();
-}
+// eslint-disable-line global-require
+if (require('electron-squirrel-startup')) app.quit();
 
 const createWindow = () => {
   // // Create the browser window.
- 
   const mainWindow = new BrowserWindow({
     width: 1280,
     height: 720,
@@ -20,12 +18,7 @@ const createWindow = () => {
   
   });
   mainWindow.loadURL(MAIN_WINDOW_WEBPACK_ENTRY);
-
-  // mainWindow.loadURL('http://localhost:3001/');
   mainWindow.webContents.openDevTools();
-  // mainWindow.loadURL(path.join(`file://${__dirname}`, `../../src/index.html`))
-  // .then(() => mainWindow.loadURL(path.join(`file://${__dirname}`, `../../src/client/app.js`)))
-  
   mainWindow.focus();
 };
 

--- a/src/server/config/passport-setup.ts
+++ b/src/server/config/passport-setup.ts
@@ -1,11 +1,11 @@
-export {};
+export { };
 
 require('dotenv').config();
 const passport = require('passport');
 const GithubStrategy = require('passport-github2');
 const { GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET } = process.env;
 
-console.log("INSIDE PASSPORTSETUP" , GITHUB_CLIENT_ID)
+console.log("INSIDE PASSPORTSETUP", GITHUB_CLIENT_ID)
 // Configure the Github strategy for use by Passport.
 //
 // OAuth 2.0-based strategies require a `verify` function which receives the
@@ -35,8 +35,7 @@ passport.use(
        * routes to 'authenticated page' w/ correct user information
        **/
       const { username } = profile;
-      console.log('PASSPORT CALLBACK FIRED FOR USER: ', username);
-      let payload: object = {
+      const payload: object = {
         username,
         accessToken
       };
@@ -52,12 +51,8 @@ passport.use(
  * supply the user ID when serializing, and query the user record by ID
  * from the database when deserializing.
  **/
-passport.serializeUser(function (payload: object, done: Function) {
-  done(null, payload);
-});
+passport.serializeUser((payload: object, done: Function) => done(null, payload));
 
-passport.deserializeUser(function (obj: object, done: Function) {
-    done(null);
-});
+passport.deserializeUser((obj: object, done: Function) => done(null));
 
-module.exports = passport.serializeUser, passport.deserializeUser ;
+module.exports = passport.serializeUser, passport.deserializeUser;

--- a/src/server/config/passport-setup.ts
+++ b/src/server/config/passport-setup.ts
@@ -4,10 +4,8 @@ require('dotenv').config();
 const passport = require('passport');
 const GithubStrategy = require('passport-github2');
 const { GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET } = process.env;
-
-console.log("INSIDE PASSPORTSETUP", GITHUB_CLIENT_ID)
 // Configure the Github strategy for use by Passport.
-//
+
 // OAuth 2.0-based strategies require a `verify` function which receives the
 // credential (`accessToken`) for accessing the Github API on the user's
 // behalf, along with the user's profile.  The function must invoke callback

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -9,7 +9,6 @@ const cookieParser = require('cookie-parser');
 require('dotenv/config');
 const app = express();
 
-
 // Bring in routes
 const authRoute = require('../../src/server/routes/auth-route');
 // const apiRoute = require('./routes/api-route');
@@ -24,22 +23,17 @@ app.use(cookieParser());
 app.use('/auth', authRoute);
 // app.use('/api', apiRoute);
 
+// Serve static files
 app.use(express.static('assets'));
 
 // Home endpoint
-app.get('/', (req: Request, res: Response) => {
-  res.sendFile(path.resolve(__dirname, '../../src/index.html'));
-});
+app.get('/', (req: Request, res: Response) => res.sendFile(path.resolve(__dirname, '../../src/index.html')));
 
-//Handle redirections
-app.get('*', (req: Request, res: Response) => {
-  // console.log('HERE HERE', req.cookies)
-  res.sendStatus(200);
-});
+// Handle redirections
+app.get('*', (req: Request, res: Response) => res.sendStatus(200));
 
-app.get('/fail', (req: Request, res: Response) => {
-  res.status(200).send('❌ FAILURE TO AUTHENTICATE ❌');
-});
+// Failed auth redirect
+app.get('/fail', (req: Request, res: Response) => res.status(200).send('❌ FAILURE TO AUTHENTICATE ❌'));
 
 // Global Error handler
 app.use((err: ErrorRequestHandler, req: Request, res: Response, next: NextFunction) => {
@@ -54,7 +48,6 @@ app.use((err: ErrorRequestHandler, req: Request, res: Response, next: NextFuncti
 
   // Update default error message with provided error if there is one
   const output = Object.assign(defaultError, err);
-
   res.send(output);
 });
 


### PR DESCRIPTION
**Added:**
- In `passport-setup.ts` → we need to use to the username for frontend display, so instead of just passing the accesstoken, a payload object was made containing both the username and accesstoken
- In `authController.ts` → the accesstoken and username are now stored in both res.locals and in cookies (needs serialization - meant for easier testing)
- In `index.html` → mock login page

**Removed:**
- Extra comments and testing code in many backend files