### PR TITLE
Clone repositories into project subfolder

### DIFF
--- a/src/client/components/home/home.tsx
+++ b/src/client/components/home/home.tsx
@@ -51,7 +51,7 @@ const Home: React.FC<HomeProps> = ({ userInfo, setUserInfo }) => {
     // dummy response
     const fetched = [
       {
-        projectName: "DockerLocal(project1)",
+        projectName: "DockerLocal",
         projectId: "one",
         projectRepos: [
           {
@@ -93,7 +93,7 @@ const Home: React.FC<HomeProps> = ({ userInfo, setUserInfo }) => {
         ],
       },
       {
-        projectName: "React Visualizer 2.5(project2)",
+        projectName: "Swell",
         projectId: "two",
         projectRepos: [
           {
@@ -117,7 +117,7 @@ const Home: React.FC<HomeProps> = ({ userInfo, setUserInfo }) => {
         ],
       },
       {
-        projectName: "React Visualizer 8.5(project3)",
+        projectName: "Chronos",
         projectId: "two and a half",
         projectRepos: [
           {
@@ -147,8 +147,68 @@ const Home: React.FC<HomeProps> = ({ userInfo, setUserInfo }) => {
         ],
       },
       {
-        projectName: "React Visualizer 77.0(project4)",
+        projectName: "ReactType",
         projectId: "four",
+        projectRepos: [
+          {
+            repoName: "organization Repo6",
+            repoOwner: "orglink5",
+            repoId: "n",
+            isIncluded: false,
+          },
+          {
+            repoName: "organization Repo7",
+            repoOwner: "orglink6",
+            repoId: "o",
+            isIncluded: false,
+          },
+          {
+            repoName: "collab Repo1",
+            repoOwner: "collablink1",
+            repoId: "p",
+            isIncluded: false,
+          },
+          {
+            repoName: "collab Repo2",
+            repoOwner: "collablink2",
+            repoId: "q",
+            isIncluded: false,
+          },
+        ],
+      },
+      {
+        projectName: "Recoilize",
+        projectId: "five",
+        projectRepos: [
+          {
+            repoName: "organization Repo6",
+            repoOwner: "orglink5",
+            repoId: "n",
+            isIncluded: false,
+          },
+          {
+            repoName: "organization Repo7",
+            repoOwner: "orglink6",
+            repoId: "o",
+            isIncluded: false,
+          },
+          {
+            repoName: "collab Repo1",
+            repoOwner: "collablink1",
+            repoId: "p",
+            isIncluded: false,
+          },
+          {
+            repoName: "collab Repo2",
+            repoOwner: "collablink2",
+            repoId: "q",
+            isIncluded: false,
+          },
+        ],
+      },
+      {
+        projectName: "Reactime",
+        projectId: "six",
         projectRepos: [
           {
             repoName: "organization Repo6",

--- a/src/client/components/projects/ProjectPage.tsx
+++ b/src/client/components/projects/ProjectPage.tsx
@@ -7,8 +7,7 @@ import ComposeFileModal from "./ComposeFileModal";
 import CloningReposModal from "./CloningReposModal";
 import { findActiveProject } from "../../helpers/projectHelper";
 import { getUsernameAndToken } from "../../helpers/cookieClientHelper";
-import { findActiveProject } from '../../helpers/projectHelper'
-
+import { findActiveProject } from "../../helpers/projectHelper";
 
 const ProjectPage: React.FC<ProjectPageProps> = ({
   activeProject,
@@ -18,14 +17,17 @@ const ProjectPage: React.FC<ProjectPageProps> = ({
 }) => {
   const [showAddRepos, setShowAddRepos] = useState(false);
   const [projectRepoListItems, setprojectRepoListItems] = useState([]);
-  
+
   const [showCloningReposModal, setShowCloningReposModal] = useState(false);
   const [showComposeModal, setShowComposeModal] = useState(false);
-  
+
   // populate repo list items when active project changes and when request from home.tsx comes back to update project list
   useEffect(() => {
-    const currentProject: Project = findActiveProject(projectList, activeProject);
-    
+    const currentProject: Project = findActiveProject(
+      projectList,
+      activeProject
+    );
+
     if (currentProject && currentProject.projectRepos) {
       const newList = currentProject.projectRepos.map((repo) => {
         return (
@@ -40,12 +42,17 @@ const ProjectPage: React.FC<ProjectPageProps> = ({
   }, [activeProject, projectList]);
 
   const cloneRepos = async () => {
-
     setShowCloningReposModal(true);
+
+    const currentProject: Project = findActiveProject(
+      projectList,
+      activeProject
+    );
+
     // get selected repos that are checked to clone
-    const reposToClone = findActiveProject(projectList, activeProject)
-      .projectRepos
-      .filter(({ isIncluded }) => isIncluded)
+    const reposToClone = currentProject.projectRepos.filter(
+      ({ isIncluded }) => isIncluded
+    );
 
     // get username and token
     const { username, accessToken } = await getUsernameAndToken();
@@ -54,6 +61,7 @@ const ProjectPage: React.FC<ProjectPageProps> = ({
       username: username,
       accessToken: accessToken,
       repos: reposToClone,
+      projectName: currentProject.projectName,
     });
 
     console.log(username, " decrypte", accessToken);
@@ -65,8 +73,8 @@ const ProjectPage: React.FC<ProjectPageProps> = ({
       },
     })
       .then((res) => {
-        setShowCloningReposModal(false)
-        return res.json()
+        setShowCloningReposModal(false);
+        return res.json();
       })
       .then((res) => console.log("success", res))
       .catch((err) => console.log("fail", err));
@@ -109,8 +117,10 @@ const ProjectPage: React.FC<ProjectPageProps> = ({
           }}
         />
       )}
-            {showCloningReposModal && (
-        <CloningReposModal {...{ showCloningReposModal, setShowCloningReposModal }} />
+      {showCloningReposModal && (
+        <CloningReposModal
+          {...{ showCloningReposModal, setShowCloningReposModal }}
+        />
       )}
 
       {showComposeModal && (

--- a/src/client/components/projects/ProjectSidebar.tsx
+++ b/src/client/components/projects/ProjectSidebar.tsx
@@ -2,8 +2,11 @@ import React, { Dispatch, SetStateAction, useState } from "react";
 import { v4 as uuidv4 } from "uuid";
 import { Project, ProjectSideBarProps } from "../../../types/types";
 
-
-const ProjectSideBar: React.FC<ProjectSideBarProps> = ({ setShowProjectSidebarModal, projectList, setProjectList }) => {
+const ProjectSideBar: React.FC<ProjectSideBarProps> = ({
+  setShowProjectSidebarModal,
+  projectList,
+  setProjectList,
+}) => {
   const [projectNameValue, setProjectNameValue] = useState("");
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>): void => {

--- a/src/scripts/cloneRepo.sh
+++ b/src/scripts/cloneRepo.sh
@@ -4,6 +4,7 @@
 # handle incoming arguments, username and repoName
 username=$1
 repoName=$2
+projectName=$3
 
 # get the sock address of our ssh agent so that we can connect to it
 temp_sock=$(cat ./tmpAgent/agentSock)
@@ -15,8 +16,13 @@ if [ ! -d "./myRepos" ]
 then
 mkdir ./myRepos
 fi
-
 cd myRepos
+# create a folder named after the current project if one doesn't exist already
+if [ ! -d "./$projectName" ] 
+mkdir $projectName
+fi
+
+cd $projectName
 
 # clone a git repository from github using ssh connection
 git clone git@github.com:$username/$repoName.git

--- a/src/scripts/cloneRepo.sh
+++ b/src/scripts/cloneRepo.sh
@@ -14,12 +14,13 @@ export SSH_AUTH_SOCK=$temp_sock
 # create a myRepos folder to store repositories if it doesn't already exist
 if [ ! -d "./myRepos" ] 
 then
-mkdir ./myRepos
+  mkdir ./myRepos
 fi
 cd myRepos
 # create a folder named after the current project if one doesn't exist already
 if [ ! -d "./$projectName" ] 
-mkdir $projectName
+then
+  mkdir $projectName
 fi
 
 cd $projectName

--- a/src/server/controllers/authController.ts
+++ b/src/server/controllers/authController.ts
@@ -56,10 +56,11 @@ authController.saveUserInfoAndRepos = (
   next: NextFunction
 ) => {
   // save username, access token and repos from request body
-  const { username, accessToken, repos }: any = req.body;
+  const { username, accessToken, repos, projectName }: any = req.body;
   res.locals.username = username;
   res.locals.accessToken = accessToken;
   res.locals.repos = repos;
+  res.locals.projectName = projectName;
   return next();
 };
 

--- a/src/server/controllers/gitController.ts
+++ b/src/server/controllers/gitController.ts
@@ -1,4 +1,4 @@
-export { };
+export {};
 
 import { Request, Response, NextFunction } from "express";
 
@@ -16,28 +16,30 @@ gitController.cloneRepo = async (
   res: Response,
   next: NextFunction
 ) => {
-  console.log('request')
+  console.log("request");
 
-  const { repos } = res.locals;
+  const { repos, projectName } = res.locals;
   const shellCommand = "./src/scripts/cloneRepo.sh";
 
   // make an array of promises to clone all selected repos
-  const promises = repos.map(async currentRepo => {
+  const promises = repos.map(async (currentRepo) => {
     const repoOwner = currentRepo.repoOwner;
     const repoName = currentRepo.repoName;
 
     //     // shell script clones github repo using SSH connection
-    const shellResp = await execShellCommand(shellCommand, [repoOwner, repoName]);
+    const shellResp = await execShellCommand(shellCommand, [
+      repoOwner,
+      repoName,
+      projectName,
+    ]);
     console.log("Finished Cloning Repo");
     return shellResp;
-  })
+  });
 
-  const shellResp = await Promise.all(promises)
-  console.log(shellResp)
+  const shellResp = await Promise.all(promises);
+  console.log(shellResp);
 
-  console.log('Finished cloning all repos')
-
-
+  console.log("Finished cloning all repos");
 
   return next();
 };


### PR DESCRIPTION
## Description:
- The clone repos button now clones the repositories into a subfolder with the path `/myRepos/{projectName}`
## Changes I Made:

- [X] In cloneRepo.sh, handle projectName as third argument. Script was updated to create a folder named after the project inside my repos. 

- [X] In ProjectPage.tsx, add projectName to request body on handle submit function for clone repos button.

- [X] In authController.ts, update saveUserInfoAndRepos middleware to pass projectName to res.locals

- [X] In gitController.ts, cloneRepo middleware now takes projectName from res.locals and passes it to cloneRepo.sh script

## How to Test:
- Run npm install and npm start. Login, add repos to project. Check boxes for repo you want to clone. Click clone repos button. Once it finishes cloning, you should see your repositories in `/myRepos/{projectName}`

![Screenshot_20200702_132903](https://user-images.githubusercontent.com/7851187/86406484-05e90780-bc68-11ea-8bd1-acbb74bb52fb.png)
